### PR TITLE
invalid method, api expects a get instead of post

### DIFF
--- a/src/methods/registry.ts
+++ b/src/methods/registry.ts
@@ -78,7 +78,7 @@ export class Registry extends Method {
   public async brandsLogosList(): Promise<Array<BrandLogo>> {
     const url = `registry/alllogos`
 
-    const response = await this.axiosClient.post<BrandsLogosListResponse>(
+    const response = await this.axiosClient.get<BrandsLogosListResponse>(
       url,
       {}
     )


### PR DESCRIPTION
This change targets the registry methods file from line 69 to 88
![image](https://github.com/Pater999/osservaprezzi-carburanti-node/assets/21222491/82ef68d0-3cc1-4b18-abfa-defb26ff5766)

specifically the request method, was changed from post to get.
I ran into this problem trying to retrieve the logos of the various fuel brands.

after some testing i noticed that with POST requests the mise API responds with 405 (Method Not Allowed), instead with a GET request i get 200 (OK)

See below:

With **POST** request
![image](https://github.com/Pater999/osservaprezzi-carburanti-node/assets/21222491/d93e4970-2808-488b-ba10-f7d5ea3b4a5a)

With **GET** request
![image](https://github.com/Pater999/osservaprezzi-carburanti-node/assets/21222491/45c2d025-c034-4d8b-a0f3-c9ca78f27f3d)
